### PR TITLE
Add browser demo for SRT parsing

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,0 +1,162 @@
+import { parseSync, stringifySync } from '../dist/subtitle.esm.js'
+
+const dropZone = document.getElementById('drop-zone')
+const fileInput = document.getElementById('file-input')
+const fileList = document.getElementById('file-list')
+const outputList = document.getElementById('output-list')
+const downloadAllBtn = document.getElementById('download-all')
+const settingsBtn = document.getElementById('open-settings')
+const settingsPane = document.getElementById('settings')
+const closeSettings = document.getElementById('close-settings')
+
+const fmtTxt = document.getElementById('fmt-txt')
+const fmtSrt = document.getElementById('fmt-srt')
+const fmtVtt = document.getElementById('fmt-vtt')
+const fmtJson = document.getElementById('fmt-json')
+const removeTags = document.getElementById('remove-tags')
+const lineJoin = document.getElementById('line-join')
+
+const outputs = []
+
+settingsBtn.onclick = () => settingsPane.classList.remove('hidden')
+closeSettings.onclick = () => settingsPane.classList.add('hidden')
+
+const preventDefaults = e => {
+  e.preventDefault()
+  e.stopPropagation()
+}
+
+;['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+  dropZone.addEventListener(eventName, preventDefaults, false)
+})
+
+;['dragenter', 'dragover'].forEach(eventName => {
+  dropZone.addEventListener(eventName, () => dropZone.classList.add('drag'))
+})
+
+;['dragleave', 'drop'].forEach(eventName => {
+  dropZone.addEventListener(eventName, () => dropZone.classList.remove('drag'))
+})
+
+dropZone.addEventListener('drop', e => {
+  handleFiles(e.dataTransfer.files)
+})
+
+fileInput.addEventListener('change', e => {
+  handleFiles(e.target.files)
+})
+
+function handleFiles(files) {
+  ;[...files].forEach(file => {
+    const reader = new FileReader()
+    reader.onload = () => processFile(file, reader.result)
+    reader.readAsText(file)
+  })
+}
+
+function processFile(file, text) {
+  let nodes
+  try {
+    nodes = parseSync(text)
+  } catch (err) {
+    const li = document.createElement('li')
+    li.textContent = `${file.name} - error parsing`
+    fileList.appendChild(li)
+    return
+  }
+
+  const cueCount = nodes.filter(n => n.type === 'cue').length
+  const li = document.createElement('li')
+  const preview = document.createElement('details')
+  preview.innerHTML = '<summary>' + file.name + ` (${cueCount} cues)</summary>`
+  const previewList = document.createElement('ol')
+  nodes.filter(n => n.type === 'cue').slice(0, 3).forEach(c => {
+    const item = document.createElement('li')
+    item.textContent = c.data.text.replace(/\n/g, ' ')
+    previewList.appendChild(item)
+  })
+  preview.appendChild(previewList)
+  li.appendChild(preview)
+  fileList.appendChild(li)
+
+  const processed = removeTags.checked
+    ? nodes.map(n =>
+        n.type === 'cue'
+          ? { ...n, data: { ...n.data, text: n.data.text.replace(/<[^>]+>/g, '') } }
+          : n
+      )
+    : nodes
+
+  const baseName = file.name.replace(/\.[^.]+$/, '')
+
+  const selectedOutputs = []
+
+  if (fmtTxt.checked) {
+    const txt = buildDialogue(processed)
+    const name = `${baseName}.dialogue.txt`
+    selectedOutputs.push({ name, content: txt })
+  }
+
+  if (fmtSrt.checked) {
+    const srt = stringifySync(processed)
+    const name = `${baseName}.clean.srt`
+    selectedOutputs.push({ name, content: srt })
+  }
+
+  if (fmtVtt.checked) {
+    const vtt = stringifySync(processed, { format: 'WebVTT' })
+    const name = `${baseName}.vtt`
+    selectedOutputs.push({ name, content: vtt })
+  }
+
+  if (fmtJson.checked) {
+    const json = JSON.stringify(processed, null, 2)
+    const name = `${baseName}.json`
+    selectedOutputs.push({ name, content: json })
+  }
+
+  selectedOutputs.forEach(out => {
+    outputs.push(out)
+    const li = document.createElement('li')
+    const a = createDownloadLink(out.content, out.name)
+    li.appendChild(a)
+    outputList.appendChild(li)
+  })
+
+  downloadAllBtn.disabled = outputs.length === 0
+}
+
+function buildDialogue(nodes) {
+  const join = lineJoin.value
+  const cues = nodes.filter(n => n.type === 'cue')
+  return cues
+    .map(c => {
+      let text = c.data.text
+      if (join === 'cue') text = text.replace(/\n/g, ' ')
+      return text
+    })
+    .join(join === 'all' ? ' ' : '\n')
+}
+
+function createDownloadLink(content, name) {
+  const blob = new Blob([content], { type: 'text/plain' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = name
+  a.textContent = `Download ${name}`
+  return a
+}
+
+downloadAllBtn.addEventListener('click', () => {
+  const zip = new JSZip()
+  outputs.forEach(out => zip.file(out.name, out.content))
+  zip.generateAsync({ type: 'blob' }).then(blob => {
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'subtitles.zip'
+    a.click()
+    URL.revokeObjectURL(url)
+  })
+})

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>subtitle.js Demo</title>
+  <style>
+    body { font-family: sans-serif; margin: 0; }
+    header { display: flex; justify-content: space-between; padding: 0.5rem 1rem; background: #333; color: white; }
+    main { display: flex; height: calc(100vh - 48px); }
+    section { flex: 1; padding: 1rem; overflow: auto; }
+    #input { border-right: 1px solid #ccc; }
+    #drop-zone { border: 2px dashed #ccc; padding: 2rem; text-align: center; margin-bottom: 1rem; }
+    #drop-zone.drag { background: #eef; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 0.5rem; }
+    #settings { position: fixed; top: 10%; right: 10%; background: white; border: 1px solid #ccc; padding: 1rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); }
+    #settings.hidden { display: none; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>subtitle.js Demo</h1>
+    <button id="open-settings">Settings</button>
+  </header>
+
+  <div id="settings" class="hidden">
+    <h2>Settings</h2>
+    <fieldset>
+      <legend>Output formats</legend>
+      <label><input type="checkbox" id="fmt-txt" checked /> TXT (dialogue)</label><br />
+      <label><input type="checkbox" id="fmt-srt" /> Clean SRT</label><br />
+      <label><input type="checkbox" id="fmt-vtt" /> WebVTT</label><br />
+      <label><input type="checkbox" id="fmt-json" /> JSON</label>
+    </fieldset>
+    <fieldset>
+      <legend>Tag handling</legend>
+      <label><input type="checkbox" id="remove-tags" checked /> Remove HTML-like tags</label>
+    </fieldset>
+    <fieldset>
+      <legend>Line joining (dialogue)</legend>
+      <select id="line-join">
+        <option value="keep">Keep line breaks</option>
+        <option value="cue">Join lines per cue</option>
+        <option value="all">Join all</option>
+      </select>
+    </fieldset>
+    <button id="close-settings">Close</button>
+  </div>
+
+  <main>
+    <section id="input">
+      <div id="drop-zone">Drop SRT files here or <input type="file" id="file-input" multiple accept=".srt" /></div>
+      <ul id="file-list"></ul>
+    </section>
+    <section id="output">
+      <button id="download-all" disabled>Download All</button>
+      <ul id="output-list"></ul>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+  <script type="module" src="./demo.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create simple single-page demo with drag-and-drop SRT input
- support output formats, tag removal and line joining
- enable per-file downloads and batch zip download

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6101e43808330aec4dedda1453712